### PR TITLE
add github-actions config to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adding Dependabot configuration to keep Github Actions up-to-date.

This PR was generated en-masse using microplane.

See: <https://github.com/vivantehealth/zi/issues/6781>
